### PR TITLE
fix: use zstd for squashfs

### DIFF
--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -88,4 +88,4 @@ AppImage:
   sign-key: None
   # https://github.com/AppImage/AppImageKit/releases/
   arch: ${TARGET_ARCH_APPIMAGE}
-  comp: xz
+  comp: zstd


### PR DESCRIPTION
As xz was removed upstream.
https://github.com/AppImage/type2-runtime/issues/118

Fixes https://github.com/goldstar611/chirp-appimage/issues/12

Verified on Fedora 43
Patched release: https://github.com/Beanow/chirp-appimage/releases/tag/next-20260109
Action logs: https://github.com/Beanow/chirp-appimage/actions/runs/20878748493